### PR TITLE
fix name bug

### DIFF
--- a/php/vendor/driver/QiniuDriver.class.php
+++ b/php/vendor/driver/QiniuDriver.class.php
@@ -243,7 +243,7 @@ class QiniuDriver{
 			}else{
 				$save_name = pathinfo($field_name, PATHINFO_EXTENSION);
 			}
-			$file_name = $prefix . $format.'/'.time().mt_rand(0,10).'.'.$save_name;
+			$file_name = $prefix . $format.'/'.time().mt_rand(0,215909581).'.'.$save_name;
 		}else{
 			// 不是远程抓取
 			if( !$flag ){


### PR DESCRIPTION
原本使用时间+1位随机数进行命名
实际应用中发现随机数10以内很容易重复,导致前面的图被后面的同名图片覆盖.
修改为一个大点的随机数后再无重复.